### PR TITLE
Fixed extraction of json files

### DIFF
--- a/harx.go
+++ b/harx.go
@@ -74,7 +74,7 @@ func decode(str []byte, fileName string) {
 }
 
 func (c *HContent) writeTo(f string) {
-	if strings.Index(c.MimeType, "text") != -1 || strings.Index(c.MimeType, "javascript") != -1 {
+	if strings.Index(c.MimeType, "text") != -1 || strings.Index(c.MimeType, "javascript") != -1 || strings.Index(c.MimeType, "json") != -1 {
 		ioutil.WriteFile(f, []byte(c.Text), os.ModePerm)
 	} else {
 		decode([]byte(c.Text), f)


### PR DESCRIPTION
Fixed a small bug where json files with "application/json" mimetype were getting base 64 decoded.
