### PR TITLE
Fix decode of non-base64 application/octet-stream

### DIFF
--- a/harx.go
+++ b/harx.go
@@ -93,13 +93,10 @@ var textContentPattern = regexp.MustCompile("text|json|javascript|ecmascript|xml
 func (c *HContent) writeTo(desiredFileName string) {
 	f := getNoDuplicatePath(desiredFileName)
 
-	switch {
-	case strings.EqualFold(c.Encoding, "base64"):
+	if strings.EqualFold(c.Encoding, "base64") {
 		decode(c.Text, f)
-	case textContentPattern.MatchString(c.MimeType):
+	} else {
 		ioutil.WriteFile(f, []byte(c.Text), os.ModePerm)
-	default:
-		decode(c.Text, f)
 	}
 }
 

--- a/harx.go
+++ b/harx.go
@@ -82,7 +82,7 @@ func (e *HEntry) dumpDirectly(dir string) {
 func decode(str string, fileName string) {
 	data, err := base64.StdEncoding.DecodeString(str)
 	if err != nil {
-		log.Fatal(err," fileName:", fileName)
+		log.Fatal(err, " fileName:", fileName)
 	} else {
 		ioutil.WriteFile(fileName, data, os.ModePerm)
 	}


### PR DESCRIPTION
This uses the encoding entirely and not the mime type to determine whether to decode the content. This allowed me to decode a (corrected) HAR file from Firefox that included XML that had been served with application/octet-stream. The pre-correction HAR specified that it was base64 but included the file as an unencoded literal, which I think is a corresponding bug in Firefox — using the encoding field set by mime type, but the content by whether or not it needed encoding.


This may still be imperfect and perhaps a better approach is to try base64 and if it fails, write it verbatim. 


