### PR TITLE
feat(release process): added framework for compiling binaries and publishing releases to github

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,0 +1,56 @@
+{{ if .Versions -}}
+<a name="unreleased"></a>
+## [Unreleased]
+
+{{ if .Unreleased.CommitGroups -}}
+{{ range .Unreleased.CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{ range .Versions }}
+<a name="{{ .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[{{ .Tag.Name }}]{{ else }}{{ .Tag.Name }}{{ end }} - {{ datetime "2006-01-02" .Tag.Date }}
+{{ range .CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+
+{{- if .RevertCommits -}}
+### Reverts
+{{ range .RevertCommits -}}
+- {{ .Revert.Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .MergeCommits -}}
+### Pull Requests
+{{ range .MergeCommits -}}
+- {{ .Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{- if .Versions }}
+[Unreleased]: {{ .Info.RepositoryURL }}/compare/{{ $latest := index .Versions 0 }}{{ $latest.Tag.Name }}...HEAD
+{{ range .Versions -}}
+{{ if .Tag.Previous -}}
+[{{ .Tag.Name }}]: {{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}
+{{ end -}}
+{{ end -}}
+{{ end -}}

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -1,0 +1,28 @@
+style: github
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+  repository_url: https://github.com/outersky/har-tools
+options:
+  commits:
+  commit_groups:
+    title_maps:
+      feat: Features
+      fix: Bug Fixes
+      bugfix: Bug Fixes
+      perf: Performance Improvements
+      refactor: Code Refactoring
+      chore: Chore
+  header:
+    pattern: "^(\\w*)(?:\\(([\\w\\$\\.\\-\\*\\s]*)\\))?\\:\\s(.+)$"
+    pattern_maps:
+      - Type
+      - Scope
+      - Subject
+  merges:
+    pattern: "^(.*#\\d+.*)$"
+    pattern_maps:
+      - Source
+  notes:
+    keywords:
+      - BREAKING CHANGE

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ _testmain.go
 /harx
 
 .idea
+
+# build process
+bin/
+build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+<a name="unreleased"></a>
+## [Unreleased]
+
+
+<a name="v0.0.0"></a>
+## v0.0.0 - 2020-06-20
+### Pull Requests
+- Merge pull request [#16](https://github.com/outersky/har-tools/issues/16) from codecare/master
+- Merge pull request [#12](https://github.com/outersky/har-tools/issues/12) from kor44/master
+- Merge pull request [#11](https://github.com/outersky/har-tools/issues/11) from jaytaylor/jay/readme
+- Merge pull request [#7](https://github.com/outersky/har-tools/issues/7) from Jamedjo/duplicate_safe
+- Merge pull request [#6](https://github.com/outersky/har-tools/issues/6) from imheresamir/master
+- Merge pull request [#5](https://github.com/outersky/har-tools/issues/5) from imheresamir/master
+- Merge pull request [#3](https://github.com/outersky/har-tools/issues/3) from nki2/master
+- Merge pull request [#1](https://github.com/outersky/har-tools/issues/1) from terhechte/master
+
+
+[Unreleased]: https://github.com/outersky/har-tools/compare/v0.0.0...HEAD

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+NAME=harx
+
+VERSION=$$(git describe --tags --always)
+SHORT_VERSION=$$(git describe --tags --always | awk -F '-' '{print $$1}')
+
+LDFLAGS=-ldflags=all="-X main.version=${SHORT_VERSION}"
+
+all: tools build
+
+tools:
+	GO111MODULE=off go get -u -v "github.com/mitchellh/gox"
+
+build:
+	@mkdir -p bin/
+	go get -t ./...
+	go test -v ./...
+	go build ${LDFLAGS} -o bin/${NAME} ./cmd/harx/main.go
+
+xbuild: clean
+	@mkdir -p build
+	gox \
+		-os="linux" \
+		-os="windows" \
+		-os="darwin" \
+		-arch="amd64" \
+		${LDFLAGS} \
+		-output="build/{{.Dir}}_$(VERSION)_{{.OS}}_{{.Arch}}/$(NAME)" \
+		./...
+
+package: xbuild
+	$(eval FILES := $(shell ls build))
+	@mkdir -p build/tgz
+	for f in $(FILES); do \
+		(cd $(shell pwd)/build && tar -zcvf tgz/$$f.tar.gz $$f); \
+		echo $$f; \
+	done
+
+clean:
+	@rm -rf bin/ && rm -rf build/
+
+ci: tools package
+
+.PHONY: all tools build xbuild package clean ci

--- a/cmd/harx/main.go
+++ b/cmd/harx/main.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 )
 
+var version string
+
 type Har struct {
 	Log HLog
 }
@@ -209,6 +211,7 @@ usage: harx [options] har-file
     -xu  urlPattern      dir   eXtract to [dir] with UrlPattern filter
     -xm  mimetypePattern dir   eXtract to [dir] with MimetypePattern filter
     -xmd mimetypePattern dir   eXtract to [dir] Directly without hostname and path info, with MimetypePattern filter
+    -v                         Print version information
 
     `)
 }
@@ -255,6 +258,9 @@ func main() {
 		extractAll = true
 		dir = os.Args[2]
 		fileName = os.Args[3]
+	case "-v":
+		fmt.Printf("harx version %s\n", version)
+		return
 	default:
 		help()
 		return

--- a/release.sh
+++ b/release.sh
@@ -92,12 +92,12 @@ if ! typeExists "github-release"; then
   echo ""
 else
   h1 "Creating Release in Github"
-  github-release release -u outersky -r harx -t $VERSION
+  github-release release -u outersky -r har-tools -t $VERSION
 
   for FILE in build/tgz/*; do
     asset_name="$(basename $FILE)"
     info "Uploading build asset: ${asset_name}"
-    github-release upload -u outersky -r harx -t $VERSION -n "$asset_name" -f $FILE
+    github-release upload -u outersky -r har-tools -t $VERSION -n "$asset_name" -f $FILE
   done
 
   success "Done!"

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+set +e
+
+#
+# Set Colors
+#
+
+bold="\e[1m"
+dim="\e[2m"
+underline="\e[4m"
+blink="\e[5m"
+reset="\e[0m"
+red="\e[31m"
+green="\e[32m"
+blue="\e[34m"
+
+#
+# Common Output Styles
+#
+
+h1() {
+  printf "\n${bold}${underline}%s${reset}\n" "$(echo "$@" | sed '/./,$!d')"
+}
+h2() {
+  printf "\n${bold}%s${reset}\n" "$(echo "$@" | sed '/./,$!d')"
+}
+info() {
+  printf "${dim}➜ %s${reset}\n" "$(echo "$@" | sed '/./,$!d')"
+}
+success() {
+  printf "${green}✔ %s${reset}\n" "$(echo "$@" | sed '/./,$!d')"
+}
+error() {
+  printf "${red}${bold}✖ %s${reset}\n" "$(echo "$@" | sed '/./,$!d')"
+}
+warnError() {
+  printf "${red}✖ %s${reset}\n" "$(echo "$@" | sed '/./,$!d')"
+}
+warnNotice() {
+  printf "${blue}✖ %s${reset}\n" "$(echo "$@" | sed '/./,$!d')"
+}
+note() {
+  printf "\n${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$(echo "$@" | sed '/./,$!d')"
+}
+
+typeExists() {
+  if [ $(type -P $1) ]; then
+    return 0
+  fi
+  return 1
+}
+
+if ! typeExists "git-chglog"; then
+  error "git-chglog is not installed"
+  note "To install run: go get -u github.com/git-chglog/git-chglog/cmd/git-chglog"
+  exit 1
+fi
+
+VERSION=${1}
+
+if [ "x${VERSION}x" = "xx" ]; then
+  error "Must supply version number as first argument"
+  exit 1
+fi
+
+h1 "Preparing release of $VERSION"
+
+h2 "Updating CHANGELOG.md"
+git-chglog --next-tag $VERSION -o CHANGELOG.md && git add CHANGELOG.md
+git commit -m "chore(release): $VERSION"
+
+h2 "Tagging version: $VERSION"
+git tag $VERSION
+
+note "Building assets to be uploaded"
+make ci
+
+note "Pushing branch: git push origin $(git rev-parse --abbrev-ref HEAD)"
+git push origin $(git rev-parse --abbrev-ref HEAD)
+
+note "Pushing tag: git push origin $VERSION"
+git push origin $VERSION
+
+if ! typeExists "github-release"; then
+  error "github-release is not installed"
+  note "To install run: go get -u github.com/github-release/github-release"
+
+  echo ""
+  note "What you still need to do:"
+  info "1. Update the release in github with compiled assets."
+  echo ""
+else
+  h1 "Creating Release in Github"
+  github-release release -u outersky -r harx -t $VERSION
+
+  for FILE in build/tgz/*; do
+    asset_name="$(basename $FILE)"
+    info "Uploading build asset: ${asset_name}"
+    github-release upload -u outersky -r harx -t $VERSION -n "$asset_name" -f $FILE
+  done
+
+  success "Done!"
+fi


### PR DESCRIPTION
I used this tool today and found it very useful. Thank you for putting it together!

I saw #14 and that there was not a published binary and thought I could help out. This PR brings in a pattern I use with Go tools that I maintain. It adds a `Makefile` with a generic build command, `ci` and other useful commands. The base `make` command will compile a local copy of the current changes to `bin/harx`. The `ci` command will compile a Mac OSX, Linux and Windows (all 64 bit) compatible binaries to the `build/`.

The `release.sh` helper script will generate a release (including an updated `CHANGELOG.md`) and publish it to github.

Examples in other tools I manage:
https://github.com/GoodwayGroup/gwvault
https://github.com/GoodwayGroup/gwsm
https://github.com/GoodwayGroup/gw-aws-audit

Here is an example of how this project would look on the first release: 
Demo Branch: https://github.com/clok/har-tools/tree/example/release
[CHANGELOG.md](https://github.com/clok/har-tools/blob/example/release/CHANGELOG.md)
[v1.0.0 Release](https://github.com/clok/har-tools/releases/tag/v1.0.0)

This process uses [git-chglog](https://github.com/git-chglog/git-chglog), [github-release](github.com/github-release/github-release) and [gox](https://github.com/mitchellh/gox)

I also added a `-v` version print out to help with maintaining the tool via `asdf`, `brew` or other tool managers.

Resolves #14 

Example outputs:
```
$ make
GO111MODULE=off go get -u -v "github.com/mitchellh/gox"
github.com/mitchellh/gox (download)
go get -t ./...
go test -v ./...
?   	github.com/outersky/har-tools/cmd/harx	[no test files]
go build -ldflags=all="-X main.version=$(git describe --tags --always | awk -F '-' '{print $1}')" -o bin/harx ./cmd/harx/main.go
```

```
$ make ci
GO111MODULE=off go get -u -v "github.com/mitchellh/gox"
github.com/mitchellh/gox (download)
gox \
		-os="linux" \
		-os="windows" \
		-os="darwin" \
		-arch="amd64" \
		-ldflags=all="-X main.version=$(git describe --tags --always | awk -F '-' '{print $1}')" \
		-output="build/{{.Dir}}_$(git describe --tags --always)_{{.OS}}_{{.Arch}}/harx" \
		./...
Number of parallel builds: 7

-->    darwin/amd64: github.com/outersky/har-tools/cmd/harx
-->   windows/amd64: github.com/outersky/har-tools/cmd/harx
-->     linux/amd64: github.com/outersky/har-tools/cmd/harx
for f in harx_279e439_darwin_amd64 harx_279e439_linux_amd64 harx_279e439_windows_amd64; do \
		(cd /Users/dsmith/github/har-tools/build && tar -zcvf tgz/$f.tar.gz $f); \
		echo $f; \
	done
a harx_279e439_darwin_amd64
a harx_279e439_darwin_amd64/harx
harx_279e439_darwin_amd64
a harx_279e439_linux_amd64
a harx_279e439_linux_amd64/harx
harx_279e439_linux_amd64
a harx_279e439_windows_amd64
a harx_279e439_windows_amd64/harx.exe
harx_279e439_windows_amd64
```

### ./release.sh <tag>
![image](https://user-images.githubusercontent.com/1429775/97789975-cccb9000-1b92-11eb-9451-5112ac155d45.png)
